### PR TITLE
Simulate subaddress generate duplication

### DIFF
--- a/BTCPayServer.Plugins.IntegrationTests/Monero/IntegrationTestUtils.cs
+++ b/BTCPayServer.Plugins.IntegrationTests/Monero/IntegrationTestUtils.cs
@@ -34,22 +34,28 @@ public static class IntegrationTestUtils
         }.Uri
     };
 
-    public static async ValueTask CleanUpAsync()
+    public static async ValueTask CleanUpAsync(bool dropDatabase = true)
     {
         await CloseTestXmrWalletFilesViaRpc();
         if (RunsInContainer)
         {
             DeleteWalletInContainer();
-            await DropDatabaseAsync(
-                "btcpayserver",
-                "Host=postgres;Port=5432;Username=postgres;Database=postgres");
+            if (dropDatabase)
+            {
+                await DropDatabaseAsync(
+                    "btcpayserver",
+                    "Host=postgres;Port=5432;Username=postgres;Database=postgres");
+            }
         }
         else
         {
             await RemoveWalletFromLocalDocker();
-            await DropDatabaseAsync(
-                "btcpayserver",
-                "Host=localhost;Port=39372;Username=postgres;Database=postgres");
+            if (dropDatabase)
+            {
+                await DropDatabaseAsync(
+                    "btcpayserver",
+                    "Host=localhost;Port=39372;Username=postgres;Database=postgres");
+            }
         }
     }
 

--- a/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
+++ b/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
@@ -19,6 +19,42 @@ namespace BTCPayServer.Plugins.IntegrationTests.Monero;
 public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroIntegrationTestBase(helper)
 {
     [Fact]
+    public async Task ShouldFailSubaddressIndexWhenOutOfSync()
+    {
+        await using var s = CreatePlaywrightTester();
+        s.Server.PayTester.BindAllInterfaces = true;
+        await s.StartAsync();
+
+        await SetupStoreWithXmrAndCreateInvoice(s, amount: "4.20",
+            "9w62SzNLhi5N2LoAas2DuTgMmwNjbyvqfR4ZNkKt7wsD7P341t9bkJWjG625YPdwMd8K5292EWAaAWCQQKj1Kc7ASkpKXcM",
+            "fc3d3ba5b8055991c51c3ba71df470b4a8920248e430584439baaf53ae4c750a");
+
+        await IntegrationTestUtils.CleanUpAsync(false);
+
+        IMoneroRpcProvider moneroRpcProvider = s.Server.PayTester.GetService<IMoneroRpcProvider>();
+        await moneroRpcProvider.WalletRpcClients["XMR"]
+            .SendCommandAsync<GenerateFromKeysRequest, GenerateFromKeysResponse>("generate_from_keys", new GenerateFromKeysRequest
+            {
+                PrimaryAddress =
+                        "9w62SzNLhi5N2LoAas2DuTgMmwNjbyvqfR4ZNkKt7wsD7P341t9bkJWjG625YPdwMd8K5292EWAaAWCQQKj1Kc7ASkpKXcM",
+                PrivateViewKey = "fc3d3ba5b8055991c51c3ba71df470b4a8920248e430584439baaf53ae4c750a",
+                WalletFileName = "wallet",
+                Password = ""
+            }, TestContext.Current.CancellationToken);
+
+        await Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await s.Page.Locator("a.nav-link[href*='invoices']").ClickAsync();
+        await s.Page.Locator("#page-primary").ClickAsync();
+        await s.Page.FillAsync("#Amount", "4.20");
+        await s.Page.FillAsync("#BuyerEmail", "monero-test@monero.com");
+        await s.Page.Locator("#page-primary").ClickAsync();
+
+        // Fails to view the last invoice
+        await s.Page.Locator("a[href^='/i/']").GetAttributeAsync("href");
+    }
+
+    [Fact]
     public async Task ShouldSettleInvoiceAfterPartialThenFullPayment()
     {
         await using var s = CreatePlaywrightTester();
@@ -28,6 +64,8 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         var invoiceId = await SetupStoreWithXmrAndCreateInvoice(s, amount: "4.20",
             "9yEzCbcYdg6MqZ5AkEh8V3YCriyN1tvmtWEHdBEUHkF6D6kN1MMD2Kd2QVWoTY67aNHNYKMUP3xfteLS2QNavJxpJdx6mWj",
             "1f4668e8c1979b4c7dae13dc149fd95cd7ff2883becffe160c21f9e02c821c08");
+
+        await CheckInvoiceDetails(s.Page, invoiceId, "4.20");
 
         // Pay half of the invoice
         await PayInvoice(s.Page, divisor: 2);
@@ -74,6 +112,8 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         var invoiceId = await SetupStoreWithXmrAndCreateInvoice(s, amount: "4.20",
             "9vGsWQCtxCWBXQBsmiRvPpgzNw6CL5ANqLip4UH8xXW7FrszpZTeAQdPxDp5H1vPnWa6UxFovxqqGBZQUnZ9i9GFBir3eHV",
             "31d082a3fab955ec6abe83d0edbfae7a0fbae66358230ee3eb01c155c32e880d");
+
+        await CheckInvoiceDetails(s.Page, invoiceId, "4.20");
 
         // Pay half of the invoice
         (decimal halfOfTheOriginalPay, string originalAddress) = await PayInvoice(s.Page, divisor: 2);
@@ -183,19 +223,21 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.Page.FillAsync("#BuyerEmail", "monero@monero.com");
         await s.Page.Locator("#page-primary").ClickAsync();
 
-        // View the invoice
+        // Get invoice ID
         var href = await s.Page.Locator("a[href^='/i/']").GetAttributeAsync("href");
         var invoiceId = href?.Split("/i/").Last()!;
-        await s.Page.Locator($"a[href='/i/{invoiceId}']").ClickAsync();
-        await s.Page.ClickAsync("#DetailsToggle");
+        return invoiceId;
+    }
 
-        // Verify the total fiat amount
-        var totalFiat = await s.Page
+    private static async Task CheckInvoiceDetails(IPage page, string invoiceId, string expectedAmount)
+    {
+        await page.Locator($"a[href='/i/{invoiceId}']").ClickAsync();
+        await page.ClickAsync("#DetailsToggle");
+
+        var totalFiat = await page
             .Locator("#PaymentDetails-TotalFiat dd.clipboard-button")
             .InnerTextAsync();
-        Assert.Equal($"${amount}", totalFiat);
-
-        return invoiceId;
+        Assert.Equal($"${expectedAmount}", totalFiat);
     }
 
     private static async Task AssertPartialPaymentState(IPage page, string invoiceId)

--- a/BTCPayServer.Plugins.UnitTests/Monero/Payments/MoneroFeeCalculationTests.cs
+++ b/BTCPayServer.Plugins.UnitTests/Monero/Payments/MoneroFeeCalculationTests.cs
@@ -77,7 +77,7 @@ public class MoneroFeeCalculationTests
             {
                 GetFeeRate = Task.FromResult(feeEstimate),
                 ReserveAddress =
-                    s => Task.FromResult(new CreateAddressResponse { Address = "fake-xmr-address", Index = 0 }),
+                    _ => Task.FromResult(new CreateAddressResponse { Address = "fake-xmr-address", Index = 0 }),
                 AccountIndex = 0
             }
         };

--- a/Plugins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
+++ b/Plugins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
@@ -5,7 +5,12 @@ using BTCPayServer.Data;
 using BTCPayServer.Payments;
 using BTCPayServer.Plugins.Monero.Services;
 using BTCPayServer.Plugins.Monero.Utils;
+using BTCPayServer.Services.Invoices;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Monero.Common;
 using Monero.Daemon.Common;
 using Monero.Daemon.Rpc;
 using Monero.Wallet.Rpc;
@@ -17,14 +22,19 @@ namespace BTCPayServer.Plugins.Monero.Payments;
 
 public class MoneroLikePaymentMethodHandler(
     MoneroLikeSpecificBtcPayNetwork network,
-    IMoneroRpcProvider moneroRpcProvider)
+    IMoneroRpcProvider moneroRpcProvider,
+    ApplicationDbContextFactory applicationDbContextFactory,
+    ILogger<MoneroLikePaymentMethodHandler> logger)
     : IPaymentMethodHandler
 {
     public JsonSerializer Serializer { get; } = BlobSerializer.CreateSerializer().Serializer;
     public PaymentMethodId PaymentMethodId { get; } = PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode);
 
-    bool IsReady() => moneroRpcProvider.IsConfigured(network.CryptoCode) &&
-                      moneroRpcProvider.IsAvailable(network.CryptoCode);
+    private bool IsReady()
+    {
+        return moneroRpcProvider.IsConfigured(network.CryptoCode) &&
+               moneroRpcProvider.IsAvailable(network.CryptoCode);
+    }
 
     public Task BeforeFetchingRates(PaymentMethodContext context)
     {
@@ -32,9 +42,9 @@ public class MoneroLikePaymentMethodHandler(
         context.Prompt.Divisibility = network.Divisibility;
         if (context.Prompt.Activated && IsReady())
         {
-            var supportedPaymentMethod = ParsePaymentMethodConfig(context.PaymentMethodConfig);
-            var walletClient = moneroRpcProvider.WalletRpcClients[network.CryptoCode];
-            var daemonClient = moneroRpcProvider.DaemonRpcClients[network.CryptoCode];
+            MoneroPaymentPromptDetails supportedPaymentMethod = ParsePaymentMethodConfig(context.PaymentMethodConfig);
+            MoneroRpcConnection walletClient = moneroRpcProvider.WalletRpcClients[network.CryptoCode];
+            MoneroRpcConnection daemonClient = moneroRpcProvider.DaemonRpcClients[network.CryptoCode];
             try
             {
                 context.State = new Prepare
@@ -55,8 +65,7 @@ public class MoneroLikePaymentMethodHandler(
             }
             catch (Exception ex)
             {
-                context.Logs.Write($"Error in BeforeFetchingRates: {ex.Message}",
-                    InvoiceEventData.EventSeverity.Error);
+                logger.LogError(ex, "Error in BeforeFetchingRates");
             }
         }
 
@@ -76,11 +85,33 @@ public class MoneroLikePaymentMethodHandler(
             throw new PaymentMethodUnavailableException("Node or wallet not available");
         }
 
-        var invoice = context.InvoiceEntity;
-        var feeAtomicRatePerByte = await moneroPrepare.GetFeeRate;
-        var address = await moneroPrepare.ReserveAddress(invoice.Id);
+        InvoiceEntity invoice = context.InvoiceEntity;
+        GetFeeEstimateResponse feeAtomicRatePerByte = await moneroPrepare.GetFeeRate;
+        CreateAddressResponse address = await moneroPrepare.ReserveAddress(invoice.Id);
+        await using (ApplicationDbContext db = applicationDbContextFactory.CreateContext())
+        {
+            int attempts = 1;
+            const int maxAttempts = 5;
+            while (await db.AddressInvoices.AnyAsync(a => a.Address == address.Address))
+            {
+                logger.LogWarning(
+                    "Subaddress collision detected for invoice {InvoiceId}: address {Address} (index {AddressIndex})" +
+                    " already exists, reserving a new one (attempt {Attempt}/{MaxAttempts})",
+                    invoice.Id, address.Address, address.Index, attempts, maxAttempts);
 
-        var details = new MoneroLikeOnChainPaymentMethodDetails
+                if (++attempts > maxAttempts)
+                {
+                    throw new PaymentMethodUnavailableException(
+                        $"Unable to reserve a unique Monero subaddress after {maxAttempts} attempts");
+                }
+
+                address = await moneroPrepare.ReserveAddress(invoice.Id);
+            }
+        }
+
+        await moneroRpcProvider.StoreWallet(network.CryptoCode);
+
+        MoneroLikeOnChainPaymentMethodDetails details = new()
         {
             AccountIndex = moneroPrepare.AccountIndex,
             AddressIndex = address.Index,
@@ -89,9 +120,9 @@ public class MoneroLikePaymentMethodHandler(
         };
         context.Prompt.Destination = address.Address;
         // Multiply by 1500 bytes, which is a reasonable approximate weight of a 1-in/2-out Monero transaction.
-        var estimatedFee = feeAtomicRatePerByte.Fee * 1500;
+        uint estimatedFee = feeAtomicRatePerByte.Fee * 1500;
         // Round up to the nearest multiple of QuantizationMask
-        var quantizedFee = RoundUpToMask(estimatedFee, feeAtomicRatePerByte.QuantizationMask);
+        long quantizedFee = RoundUpToMask(estimatedFee, feeAtomicRatePerByte.QuantizationMask);
         context.Prompt.PaymentMethodFee = MoneroMoney.Convert(quantizedFee);
         context.Prompt.Details = JObject.FromObject(details, Serializer);
         context.TrackedDestinations.Add(address.Address);
@@ -104,7 +135,7 @@ public class MoneroLikePaymentMethodHandler(
             return value;
         }
 
-        var remainder = value % mask;
+        long remainder = value % mask;
         return remainder == 0 ? value : value + (mask - remainder);
     }
 

--- a/Plugins/Monero/Services/MoneroRpcProvider.cs
+++ b/Plugins/Monero/Services/MoneroRpcProvider.cs
@@ -20,6 +20,7 @@ public interface IMoneroRpcProvider
     bool IsAvailable(string cryptoCode);
     string GetWalletDirectory(string cryptoCode);
     Task CloseWallet(string cryptoCode);
+    Task StoreWallet(string cryptoCode);
     Task<MoneroRpcProvider.MoneroLikeSummary> UpdateSummary(string cryptoCode);
     ConcurrentDictionary<string, MoneroRpcProvider.MoneroLikeSummary> Summaries { get; }
     ImmutableDictionary<string, MoneroRpcConnection> DaemonRpcClients { get; }
@@ -72,6 +73,17 @@ public class MoneroRpcProvider : IMoneroRpcProvider
 
         await walletRpcClient.SendCommandAsync<NoRequestModel, object>(
             "close_wallet", NoRequestModel.Instance);
+    }
+
+    public async Task StoreWallet(string cryptoCode)
+    {
+        if (!WalletRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var walletRpcClient))
+        {
+            throw new InvalidOperationException($"Wallet RPC client not found for {cryptoCode}");
+        }
+
+        await walletRpcClient.SendCommandAsync<NoRequestModel, object>(
+            "store", NoRequestModel.Instance);
     }
 
     public string GetWalletDirectory(string cryptoCode)


### PR DESCRIPTION
This PR simulates the `duplicate key value violates unique constraint "PK_AddressInvoices"` from https://github.com/btcpay-monero/btcpayserver-monero-plugin/issues/57

**High level steps:**

1. test `ShouldFailSubaddressIndexWhenOutOfSync` creates a view wallet and generates an invoice ([subaddress](https://github.com/monero-project/monero/blob/master/src/wallet/wallet2.cpp#L1580))
2. it then removes the view_wallet with view_wallet.keys..
3. test runs further without dropping the db and creating the same view wallet again.. and tries to generate an invoice but it fails as this subaddress violates the unique constrain on db

**Wanted behavior:**

A unique subaddress should be generated under all circumstances.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Monero invoice handling by saving wallet state during payment setup and avoiding reserved-address conflicts.
  * Improved cleanup behavior so wallet data can be reset without always removing the database.
  * Added clearer error handling when Monero payment setup encounters synchronization or availability issues.

* **Tests**
  * Added coverage for Monero invoice behavior when the wallet is out of sync.
  * Updated existing Monero payment tests to share common invoice-checking logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->