### PR TITLE
Fix missed node sync notification by switching rpc to an interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,17 @@ indent_style = space
 [*.xml]
 indent_size = 2
 
+# Xml project files
+[*.{csproj,fsproj,vbproj,proj,slnx}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
 # C# files
 [*.cs]
 
@@ -18,7 +29,6 @@ indent_size = 4
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####
@@ -52,13 +62,16 @@ dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
@@ -95,6 +108,7 @@ csharp_style_expression_bodied_properties = true:silent
 # Pattern matching preferences
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
 csharp_style_prefer_not_pattern = true:suggestion
 csharp_style_prefer_pattern_matching = true:silent
 csharp_style_prefer_switch_expression = true:suggestion
@@ -103,20 +117,31 @@ csharp_style_prefer_switch_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences
+csharp_prefer_static_anonymous_function = true:suggestion
 csharp_prefer_static_local_function = true:warning
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+csharp_preferred_modifier_order = public,private,protected,internal,file,const,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
 
 # Code-block preferences
 csharp_prefer_braces = true:silent
 csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
 
 # Expression-level preferences
 csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
 csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent

--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <Product>Monero</Product>
     <Description>This plugin extends BTCPay Server to enable users to receive payments via Monero.</Description>
-    <Version>1.3.4</Version>
+    <Version>1.3.5</Version>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 

--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <WarningsAsErrors>$(WarningsAsErrors);IDE0161</WarningsAsErrors>
   </PropertyGroup>
 
   <!-- Plugin specific properties -->

--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.json
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.json
@@ -1,7 +1,7 @@
 {
   "Identifier": "BTCPayServer.Plugins.Monero",
   "Name": "Monero",
-  "Version": "1.3.4",
+  "Version": "1.3.5",
   "Description": "This plugin extends BTCPay Server to enable users to receive payments via Monero.",
   "SystemPlugin": false,
   "Dependencies": [

--- a/Plugins/Monero/Configuration/MoneroLikeConfiguration.cs
+++ b/Plugins/Monero/Configuration/MoneroLikeConfiguration.cs
@@ -1,19 +1,18 @@
 using System;
 using System.Collections.Generic;
 
-namespace BTCPayServer.Plugins.Monero.Configuration
-{
-    public class MoneroLikeConfiguration
-    {
-        public Dictionary<string, MoneroLikeConfigurationItem> MoneroLikeConfigurationItems { get; set; } = [];
-    }
+namespace BTCPayServer.Plugins.Monero.Configuration;
 
-    public class MoneroLikeConfigurationItem
-    {
-        public Uri DaemonRpcUri { get; set; }
-        public Uri InternalWalletRpcUri { get; set; }
-        public string WalletDirectory { get; set; }
-        public string Username { get; set; }
-        public string Password { get; set; }
-    }
+public class MoneroLikeConfiguration
+{
+    public Dictionary<string, MoneroLikeConfigurationItem> MoneroLikeConfigurationItems { get; set; } = [];
+}
+
+public class MoneroLikeConfigurationItem
+{
+    public Uri DaemonRpcUri { get; set; }
+    public Uri InternalWalletRpcUri { get; set; }
+    public string WalletDirectory { get; set; }
+    public string Username { get; set; }
+    public string Password { get; set; }
 }

--- a/Plugins/Monero/Controllers/MoneroDaemonCallbackController.cs
+++ b/Plugins/Monero/Controllers/MoneroDaemonCallbackController.cs
@@ -2,37 +2,36 @@ using Microsoft.AspNetCore.Mvc;
 
 using Monero.Common;
 
-namespace BTCPayServer.Plugins.Monero.Controllers
+namespace BTCPayServer.Plugins.Monero.Controllers;
+
+[Route("[controller]")]
+public class MoneroLikeDaemonCallbackController : Controller
 {
-    [Route("[controller]")]
-    public class MoneroLikeDaemonCallbackController : Controller
+    private readonly EventAggregator _eventAggregator;
+
+    public MoneroLikeDaemonCallbackController(EventAggregator eventAggregator)
     {
-        private readonly EventAggregator _eventAggregator;
-
-        public MoneroLikeDaemonCallbackController(EventAggregator eventAggregator)
-        {
-            _eventAggregator = eventAggregator;
-        }
-        [HttpGet("block")]
-        public IActionResult OnBlockNotify(string hash, string cryptoCode)
-        {
-            _eventAggregator.Publish(new MoneroEvent()
-            {
-                BlockHash = hash,
-                CryptoCode = cryptoCode.ToUpperInvariant()
-            });
-            return Ok();
-        }
-        [HttpGet("tx")]
-        public IActionResult OnTransactionNotify(string hash, string cryptoCode)
-        {
-            _eventAggregator.Publish(new MoneroEvent()
-            {
-                TransactionHash = hash,
-                CryptoCode = cryptoCode.ToUpperInvariant()
-            });
-            return Ok();
-        }
-
+        _eventAggregator = eventAggregator;
     }
+    [HttpGet("block")]
+    public IActionResult OnBlockNotify(string hash, string cryptoCode)
+    {
+        _eventAggregator.Publish(new MoneroEvent()
+        {
+            BlockHash = hash,
+            CryptoCode = cryptoCode.ToUpperInvariant()
+        });
+        return Ok();
+    }
+    [HttpGet("tx")]
+    public IActionResult OnTransactionNotify(string hash, string cryptoCode)
+    {
+        _eventAggregator.Publish(new MoneroEvent()
+        {
+            TransactionHash = hash,
+            CryptoCode = cryptoCode.ToUpperInvariant()
+        });
+        return Ok();
+    }
+
 }

--- a/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
+++ b/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
@@ -24,302 +24,301 @@ using Microsoft.Extensions.Logging;
 
 using Monero.Wallet.Rpc;
 
-namespace BTCPayServer.Plugins.Monero.Controllers
-{
-    [Route("stores/{storeId}/monerolike")]
-    [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-    [Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-    public class UIMoneroLikeStoreController : Controller
-    {
-        private readonly MoneroLikeConfiguration _MoneroLikeConfiguration;
-        private readonly StoreRepository _StoreRepository;
-        private readonly IMoneroRpcProvider _MoneroRpcProvider;
-        private readonly PaymentMethodHandlerDictionary _handlers;
-        private readonly ILogger<UIMoneroLikeStoreController> _logger;
-        private IStringLocalizer StringLocalizer { get; }
+namespace BTCPayServer.Plugins.Monero.Controllers;
 
-        public UIMoneroLikeStoreController(MoneroLikeConfiguration moneroLikeConfiguration,
-            StoreRepository storeRepository, IMoneroRpcProvider moneroRpcProvider,
-            PaymentMethodHandlerDictionary handlers,
-            IStringLocalizer stringLocalizer,
-            ILogger<UIMoneroLikeStoreController> logger)
+[Route("stores/{storeId}/monerolike")]
+[Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+[Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+[Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+public class UIMoneroLikeStoreController : Controller
+{
+    private readonly MoneroLikeConfiguration _MoneroLikeConfiguration;
+    private readonly StoreRepository _StoreRepository;
+    private readonly IMoneroRpcProvider _MoneroRpcProvider;
+    private readonly PaymentMethodHandlerDictionary _handlers;
+    private readonly ILogger<UIMoneroLikeStoreController> _logger;
+    private IStringLocalizer StringLocalizer { get; }
+
+    public UIMoneroLikeStoreController(MoneroLikeConfiguration moneroLikeConfiguration,
+        StoreRepository storeRepository, IMoneroRpcProvider moneroRpcProvider,
+        PaymentMethodHandlerDictionary handlers,
+        IStringLocalizer stringLocalizer,
+        ILogger<UIMoneroLikeStoreController> logger)
+    {
+        _MoneroLikeConfiguration = moneroLikeConfiguration;
+        _StoreRepository = storeRepository;
+        _MoneroRpcProvider = moneroRpcProvider;
+        _handlers = handlers;
+        StringLocalizer = stringLocalizer;
+        _logger = logger;
+    }
+
+    public StoreData StoreData => HttpContext.GetStoreData();
+
+    [NonAction]
+    public async Task<MoneroLikePaymentMethodListViewModel> GetVM(StoreData storeData)
+    {
+        var excludeFilters = storeData.GetStoreBlob().GetExcludedPaymentMethods();
+
+        var accountsList = _MoneroLikeConfiguration.MoneroLikeConfigurationItems.ToDictionary(pair => pair.Key,
+            pair => GetAccounts(pair.Key));
+
+        await Task.WhenAll(accountsList.Values);
+        return new MoneroLikePaymentMethodListViewModel()
         {
-            _MoneroLikeConfiguration = moneroLikeConfiguration;
-            _StoreRepository = storeRepository;
-            _MoneroRpcProvider = moneroRpcProvider;
-            _handlers = handlers;
-            StringLocalizer = stringLocalizer;
-            _logger = logger;
+            Items = _MoneroLikeConfiguration.MoneroLikeConfigurationItems.Select(pair =>
+                GetMoneroLikePaymentMethodViewModel(storeData, pair.Key, excludeFilters,
+                    accountsList[pair.Key].Result))
+        };
+    }
+
+    private async Task<GetAccountsResponse> GetAccounts(string cryptoCode)
+    {
+        try
+        {
+            if (_MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary) && summary.WalletAvailable)
+            {
+                return await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GetAccountsRequest, GetAccountsResponse>("get_accounts", new GetAccountsRequest());
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get accounts for {CryptoCode}", cryptoCode);
         }
 
-        public StoreData StoreData => HttpContext.GetStoreData();
+        return null;
+    }
 
-        [NonAction]
-        public async Task<MoneroLikePaymentMethodListViewModel> GetVM(StoreData storeData)
+    private MoneroLikePaymentMethodViewModel GetMoneroLikePaymentMethodViewModel(
+        StoreData storeData, string cryptoCode,
+        IPaymentFilter excludeFilters, GetAccountsResponse accountsResponse)
+    {
+        var monero = storeData.GetPaymentMethodConfigs(_handlers)
+            .Where(s => s.Value is MoneroPaymentPromptDetails)
+            .Select(s => (PaymentMethodId: s.Key, Details: (MoneroPaymentPromptDetails)s.Value));
+        var pmi = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
+        var settings = monero.Where(method => method.PaymentMethodId == pmi).Select(m => m.Details).SingleOrDefault();
+        _MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary);
+        _MoneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode,
+            out var configurationItem);
+        var accounts = accountsResponse?.Accounts.Select(account =>
+            new SelectListItem(
+                $"{account.AccountIndex} - {(string.IsNullOrEmpty(account.Label) ? "No label" : account.Label)}",
+                account.AccountIndex.ToString()));
+
+        var settlementThresholdChoice = MoneroLikeSettlementThresholdChoice.StoreSpeedPolicy;
+        if (settings != null && settings.InvoiceSettledConfirmationThreshold is { } confirmations)
         {
-            var excludeFilters = storeData.GetStoreBlob().GetExcludedPaymentMethods();
-
-            var accountsList = _MoneroLikeConfiguration.MoneroLikeConfigurationItems.ToDictionary(pair => pair.Key,
-                pair => GetAccounts(pair.Key));
-
-            await Task.WhenAll(accountsList.Values);
-            return new MoneroLikePaymentMethodListViewModel()
+            settlementThresholdChoice = confirmations switch
             {
-                Items = _MoneroLikeConfiguration.MoneroLikeConfigurationItems.Select(pair =>
-                    GetMoneroLikePaymentMethodViewModel(storeData, pair.Key, excludeFilters,
-                        accountsList[pair.Key].Result))
+                0 => MoneroLikeSettlementThresholdChoice.ZeroConfirmation,
+                1 => MoneroLikeSettlementThresholdChoice.AtLeastOne,
+                10 => MoneroLikeSettlementThresholdChoice.AtLeastTen,
+                _ => MoneroLikeSettlementThresholdChoice.Custom
             };
         }
 
-        private async Task<GetAccountsResponse> GetAccounts(string cryptoCode)
+        return new MoneroLikePaymentMethodViewModel()
+        {
+            Enabled =
+                settings != null &&
+                !excludeFilters.Match(PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode)),
+            Summary = summary,
+            CryptoCode = cryptoCode,
+            AccountIndex = settings?.AccountIndex ?? accountsResponse?.Accounts?.FirstOrDefault()?.AccountIndex ?? 0,
+            Accounts = accounts == null ? null : new SelectList(accounts, nameof(SelectListItem.Value),
+                nameof(SelectListItem.Text)),
+            SettlementConfirmationThresholdChoice = settlementThresholdChoice,
+            CustomSettlementConfirmationThreshold =
+                settings != null &&
+                settlementThresholdChoice is MoneroLikeSettlementThresholdChoice.Custom
+                    ? settings.InvoiceSettledConfirmationThreshold
+                    : null
+        };
+    }
+
+    [HttpGet("{cryptoCode}")]
+    public async Task<IActionResult> GetStoreMoneroLikePaymentMethod(string cryptoCode)
+    {
+        cryptoCode = cryptoCode.ToUpperInvariant();
+        if (!_MoneroLikeConfiguration.MoneroLikeConfigurationItems.ContainsKey(cryptoCode))
+        {
+            return NotFound();
+        }
+
+        var vm = GetMoneroLikePaymentMethodViewModel(StoreData, cryptoCode,
+            StoreData.GetStoreBlob().GetExcludedPaymentMethods(), await GetAccounts(cryptoCode));
+        return View("/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml", vm);
+    }
+
+    [HttpPost("{cryptoCode}")]
+    public async Task<IActionResult> GetStoreMoneroLikePaymentMethod(MoneroLikePaymentMethodViewModel viewModel, string command, string cryptoCode)
+    {
+        cryptoCode = cryptoCode.ToUpperInvariant();
+        if (!_MoneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode,
+            out var configurationItem))
+        {
+            return NotFound();
+        }
+
+        if (command == "add-account")
         {
             try
             {
-                if (_MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary) && summary.WalletAvailable)
+                var newAccount = await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<CreateAccountRequest, CreateAccountResponse>("create_account", new CreateAccountRequest()
                 {
-                    return await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GetAccountsRequest, GetAccountsResponse>("get_accounts", new GetAccountsRequest());
+                    Label = viewModel.NewAccountLabel
+                });
+                viewModel.AccountIndex = newAccount.AccountIndex;
+            }
+            catch (Exception)
+            {
+                ModelState.AddModelError(nameof(viewModel.AccountIndex), StringLocalizer["Could not create a new account."]);
+            }
+
+        }
+        else if (command == "set-wallet-details")
+        {
+            var valid = true;
+            if (viewModel.PrimaryAddress == null)
+            {
+                ModelState.AddModelError(nameof(viewModel.PrimaryAddress), StringLocalizer["Please set your primary public address"]);
+                valid = false;
+            }
+            if (viewModel.PrivateViewKey == null)
+            {
+                ModelState.AddModelError(nameof(viewModel.PrivateViewKey), StringLocalizer["Please set your private view key"]);
+                valid = false;
+            }
+            if (configurationItem.WalletDirectory == null)
+            {
+                ModelState.AddModelError(nameof(viewModel.PrimaryAddress), StringLocalizer["This installation doesn't support wallet creation (BTCPAY_XMR_WALLET_DAEMON_WALLETDIR is not set)"]);
+                valid = false;
+            }
+            if (valid)
+            {
+                if (_MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary))
+                {
+                    if (summary.WalletAvailable)
+                    {
+                        TempData.SetStatusMessageModel(new StatusMessageModel
+                        {
+                            Severity = StatusMessageModel.StatusSeverity.Error,
+                            Message = StringLocalizer["There is already an active wallet configured for {0}. Replacing it would break any existing invoices!", cryptoCode].Value
+                        });
+                        return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod),
+                            new { cryptoCode });
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to get accounts for {CryptoCode}", cryptoCode);
-            }
-
-            return null;
-        }
-
-        private MoneroLikePaymentMethodViewModel GetMoneroLikePaymentMethodViewModel(
-            StoreData storeData, string cryptoCode,
-            IPaymentFilter excludeFilters, GetAccountsResponse accountsResponse)
-        {
-            var monero = storeData.GetPaymentMethodConfigs(_handlers)
-                .Where(s => s.Value is MoneroPaymentPromptDetails)
-                .Select(s => (PaymentMethodId: s.Key, Details: (MoneroPaymentPromptDetails)s.Value));
-            var pmi = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
-            var settings = monero.Where(method => method.PaymentMethodId == pmi).Select(m => m.Details).SingleOrDefault();
-            _MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary);
-            _MoneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode,
-                out var configurationItem);
-            var accounts = accountsResponse?.Accounts.Select(account =>
-                new SelectListItem(
-                    $"{account.AccountIndex} - {(string.IsNullOrEmpty(account.Label) ? "No label" : account.Label)}",
-                    account.AccountIndex.ToString()));
-
-            var settlementThresholdChoice = MoneroLikeSettlementThresholdChoice.StoreSpeedPolicy;
-            if (settings != null && settings.InvoiceSettledConfirmationThreshold is { } confirmations)
-            {
-                settlementThresholdChoice = confirmations switch
+                try
                 {
-                    0 => MoneroLikeSettlementThresholdChoice.ZeroConfirmation,
-                    1 => MoneroLikeSettlementThresholdChoice.AtLeastOne,
-                    10 => MoneroLikeSettlementThresholdChoice.AtLeastTen,
-                    _ => MoneroLikeSettlementThresholdChoice.Custom
-                };
-            }
+                    await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GenerateFromKeysRequest, GenerateFromKeysResponse>("generate_from_keys", new GenerateFromKeysRequest
+                    {
+                        PrimaryAddress = viewModel.PrimaryAddress,
+                        PrivateViewKey = viewModel.PrivateViewKey,
+                        WalletFileName = "wallet",
+                        RestoreHeight = viewModel.RestoreHeight
+                    });
+                }
+                catch (Exception ex)
+                {
+                    ModelState.AddModelError(nameof(viewModel.AccountIndex), StringLocalizer["Could not generate view wallet from keys: {0}", ex.Message]);
+                    return View("/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml", viewModel);
+                }
 
-            return new MoneroLikePaymentMethodViewModel()
-            {
-                Enabled =
-                    settings != null &&
-                    !excludeFilters.Match(PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode)),
-                Summary = summary,
-                CryptoCode = cryptoCode,
-                AccountIndex = settings?.AccountIndex ?? accountsResponse?.Accounts?.FirstOrDefault()?.AccountIndex ?? 0,
-                Accounts = accounts == null ? null : new SelectList(accounts, nameof(SelectListItem.Value),
-                    nameof(SelectListItem.Text)),
-                SettlementConfirmationThresholdChoice = settlementThresholdChoice,
-                CustomSettlementConfirmationThreshold =
-                    settings != null &&
-                    settlementThresholdChoice is MoneroLikeSettlementThresholdChoice.Custom
-                        ? settings.InvoiceSettledConfirmationThreshold
-                        : null
-            };
+                TempData.SetStatusMessageModel(new StatusMessageModel
+                {
+                    Severity = StatusMessageModel.StatusSeverity.Info,
+                    Message = StringLocalizer["View-only wallet created. The wallet will soon become available."].Value
+                });
+                return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { cryptoCode });
+            }
         }
 
-        [HttpGet("{cryptoCode}")]
-        public async Task<IActionResult> GetStoreMoneroLikePaymentMethod(string cryptoCode)
+        if (!ModelState.IsValid)
         {
-            cryptoCode = cryptoCode.ToUpperInvariant();
-            if (!_MoneroLikeConfiguration.MoneroLikeConfigurationItems.ContainsKey(cryptoCode))
-            {
-                return NotFound();
-            }
 
             var vm = GetMoneroLikePaymentMethodViewModel(StoreData, cryptoCode,
                 StoreData.GetStoreBlob().GetExcludedPaymentMethods(), await GetAccounts(cryptoCode));
+
+            vm.Enabled = viewModel.Enabled;
+            vm.NewAccountLabel = viewModel.NewAccountLabel;
+            vm.AccountIndex = viewModel.AccountIndex;
+            vm.SettlementConfirmationThresholdChoice = viewModel.SettlementConfirmationThresholdChoice;
+            vm.CustomSettlementConfirmationThreshold = viewModel.CustomSettlementConfirmationThreshold;
             return View("/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml", vm);
         }
 
-        [HttpPost("{cryptoCode}")]
-        public async Task<IActionResult> GetStoreMoneroLikePaymentMethod(MoneroLikePaymentMethodViewModel viewModel, string command, string cryptoCode)
+        var storeData = StoreData;
+        var blob = storeData.GetStoreBlob();
+        storeData.SetPaymentMethodConfig(_handlers[PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode)], new MoneroPaymentPromptDetails()
         {
-            cryptoCode = cryptoCode.ToUpperInvariant();
-            if (!_MoneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode,
-                out var configurationItem))
+            AccountIndex = viewModel.AccountIndex,
+            InvoiceSettledConfirmationThreshold = viewModel.SettlementConfirmationThresholdChoice switch
             {
-                return NotFound();
+                MoneroLikeSettlementThresholdChoice.ZeroConfirmation => 0,
+                MoneroLikeSettlementThresholdChoice.AtLeastOne => 1,
+                MoneroLikeSettlementThresholdChoice.AtLeastTen => 10,
+                MoneroLikeSettlementThresholdChoice.Custom when viewModel.CustomSettlementConfirmationThreshold is { } custom => custom,
+                _ => null
             }
+        });
 
-            if (command == "add-account")
-            {
-                try
-                {
-                    var newAccount = await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<CreateAccountRequest, CreateAccountResponse>("create_account", new CreateAccountRequest()
-                    {
-                        Label = viewModel.NewAccountLabel
-                    });
-                    viewModel.AccountIndex = newAccount.AccountIndex;
-                }
-                catch (Exception)
-                {
-                    ModelState.AddModelError(nameof(viewModel.AccountIndex), StringLocalizer["Could not create a new account."]);
-                }
+        blob.SetExcluded(PaymentTypes.CHAIN.GetPaymentMethodId(viewModel.CryptoCode), !viewModel.Enabled);
+        storeData.SetStoreBlob(blob);
+        await _StoreRepository.UpdateStore(storeData);
+        return RedirectToAction("GetStoreMoneroLikePaymentMethod", new { cryptoCode });
+    }
 
-            }
-            else if (command == "set-wallet-details")
-            {
-                var valid = true;
-                if (viewModel.PrimaryAddress == null)
-                {
-                    ModelState.AddModelError(nameof(viewModel.PrimaryAddress), StringLocalizer["Please set your primary public address"]);
-                    valid = false;
-                }
-                if (viewModel.PrivateViewKey == null)
-                {
-                    ModelState.AddModelError(nameof(viewModel.PrivateViewKey), StringLocalizer["Please set your private view key"]);
-                    valid = false;
-                }
-                if (configurationItem.WalletDirectory == null)
-                {
-                    ModelState.AddModelError(nameof(viewModel.PrimaryAddress), StringLocalizer["This installation doesn't support wallet creation (BTCPAY_XMR_WALLET_DAEMON_WALLETDIR is not set)"]);
-                    valid = false;
-                }
-                if (valid)
-                {
-                    if (_MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary))
-                    {
-                        if (summary.WalletAvailable)
-                        {
-                            TempData.SetStatusMessageModel(new StatusMessageModel
-                            {
-                                Severity = StatusMessageModel.StatusSeverity.Error,
-                                Message = StringLocalizer["There is already an active wallet configured for {0}. Replacing it would break any existing invoices!", cryptoCode].Value
-                            });
-                            return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod),
-                                new { cryptoCode });
-                        }
-                    }
-                    try
-                    {
-                        await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GenerateFromKeysRequest, GenerateFromKeysResponse>("generate_from_keys", new GenerateFromKeysRequest
-                        {
-                            PrimaryAddress = viewModel.PrimaryAddress,
-                            PrivateViewKey = viewModel.PrivateViewKey,
-                            WalletFileName = "wallet",
-                            RestoreHeight = viewModel.RestoreHeight
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        ModelState.AddModelError(nameof(viewModel.AccountIndex), StringLocalizer["Could not generate view wallet from keys: {0}", ex.Message]);
-                        return View("/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml", viewModel);
-                    }
+    public class MoneroLikePaymentMethodListViewModel
+    {
+        public IEnumerable<MoneroLikePaymentMethodViewModel> Items { get; set; }
+    }
 
-                    TempData.SetStatusMessageModel(new StatusMessageModel
-                    {
-                        Severity = StatusMessageModel.StatusSeverity.Info,
-                        Message = StringLocalizer["View-only wallet created. The wallet will soon become available."].Value
-                    });
-                    return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { cryptoCode });
-                }
-            }
+    public class MoneroLikePaymentMethodViewModel : IValidatableObject
+    {
+        public MoneroRpcProvider.MoneroLikeSummary Summary { get; set; }
+        public string CryptoCode { get; set; }
+        public string NewAccountLabel { get; set; }
+        public long AccountIndex { get; set; }
+        public bool Enabled { get; set; }
 
-            if (!ModelState.IsValid)
-            {
+        public IEnumerable<SelectListItem> Accounts { get; set; }
+        public bool WalletFileFound { get; set; }
+        [Display(Name = "Primary Public Address")]
+        public string PrimaryAddress { get; set; }
+        [Display(Name = "Private View Key")]
+        public string PrivateViewKey { get; set; }
+        [Display(Name = "Restore Height")]
+        public uint RestoreHeight { get; set; }
+        [Display(Name = "Consider the invoice settled when the payment transaction …")]
+        public MoneroLikeSettlementThresholdChoice SettlementConfirmationThresholdChoice { get; set; }
+        [Display(Name = "Required Confirmations"), Range(0, 100)]
+        public int? CustomSettlementConfirmationThreshold { get; set; }
 
-                var vm = GetMoneroLikePaymentMethodViewModel(StoreData, cryptoCode,
-                    StoreData.GetStoreBlob().GetExcludedPaymentMethods(), await GetAccounts(cryptoCode));
-
-                vm.Enabled = viewModel.Enabled;
-                vm.NewAccountLabel = viewModel.NewAccountLabel;
-                vm.AccountIndex = viewModel.AccountIndex;
-                vm.SettlementConfirmationThresholdChoice = viewModel.SettlementConfirmationThresholdChoice;
-                vm.CustomSettlementConfirmationThreshold = viewModel.CustomSettlementConfirmationThreshold;
-                return View("/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml", vm);
-            }
-
-            var storeData = StoreData;
-            var blob = storeData.GetStoreBlob();
-            storeData.SetPaymentMethodConfig(_handlers[PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode)], new MoneroPaymentPromptDetails()
-            {
-                AccountIndex = viewModel.AccountIndex,
-                InvoiceSettledConfirmationThreshold = viewModel.SettlementConfirmationThresholdChoice switch
-                {
-                    MoneroLikeSettlementThresholdChoice.ZeroConfirmation => 0,
-                    MoneroLikeSettlementThresholdChoice.AtLeastOne => 1,
-                    MoneroLikeSettlementThresholdChoice.AtLeastTen => 10,
-                    MoneroLikeSettlementThresholdChoice.Custom when viewModel.CustomSettlementConfirmationThreshold is { } custom => custom,
-                    _ => null
-                }
-            });
-
-            blob.SetExcluded(PaymentTypes.CHAIN.GetPaymentMethodId(viewModel.CryptoCode), !viewModel.Enabled);
-            storeData.SetStoreBlob(blob);
-            await _StoreRepository.UpdateStore(storeData);
-            return RedirectToAction("GetStoreMoneroLikePaymentMethod", new { cryptoCode });
-        }
-
-        public class MoneroLikePaymentMethodListViewModel
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            public IEnumerable<MoneroLikePaymentMethodViewModel> Items { get; set; }
-        }
-
-        public class MoneroLikePaymentMethodViewModel : IValidatableObject
-        {
-            public MoneroRpcProvider.MoneroLikeSummary Summary { get; set; }
-            public string CryptoCode { get; set; }
-            public string NewAccountLabel { get; set; }
-            public long AccountIndex { get; set; }
-            public bool Enabled { get; set; }
-
-            public IEnumerable<SelectListItem> Accounts { get; set; }
-            public bool WalletFileFound { get; set; }
-            [Display(Name = "Primary Public Address")]
-            public string PrimaryAddress { get; set; }
-            [Display(Name = "Private View Key")]
-            public string PrivateViewKey { get; set; }
-            [Display(Name = "Restore Height")]
-            public uint RestoreHeight { get; set; }
-            [Display(Name = "Consider the invoice settled when the payment transaction …")]
-            public MoneroLikeSettlementThresholdChoice SettlementConfirmationThresholdChoice { get; set; }
-            [Display(Name = "Required Confirmations"), Range(0, 100)]
-            public int? CustomSettlementConfirmationThreshold { get; set; }
-
-            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+            if (SettlementConfirmationThresholdChoice is MoneroLikeSettlementThresholdChoice.Custom
+                && CustomSettlementConfirmationThreshold is null)
             {
-                if (SettlementConfirmationThresholdChoice is MoneroLikeSettlementThresholdChoice.Custom
-                    && CustomSettlementConfirmationThreshold is null)
-                {
-                    yield return new ValidationResult(
-                        "You must specify the number of required confirmations when using a custom threshold.",
-                        new[] { nameof(CustomSettlementConfirmationThreshold) });
-                }
+                yield return new ValidationResult(
+                    "You must specify the number of required confirmations when using a custom threshold.",
+                    new[] { nameof(CustomSettlementConfirmationThreshold) });
             }
         }
+    }
 
-        public enum MoneroLikeSettlementThresholdChoice
-        {
-            [Display(Name = "Store Speed Policy", Description = "Use the store's speed policy")]
-            StoreSpeedPolicy,
-            [Display(Name = "Zero Confirmation", Description = "Is unconfirmed")]
-            ZeroConfirmation,
-            [Display(Name = "At Least One", Description = "Has at least 1 confirmation")]
-            AtLeastOne,
-            [Display(Name = "At Least Ten", Description = "Has at least 10 confirmations")]
-            AtLeastTen,
-            [Display(Name = "Custom", Description = "Custom")]
-            Custom
-        }
+    public enum MoneroLikeSettlementThresholdChoice
+    {
+        [Display(Name = "Store Speed Policy", Description = "Use the store's speed policy")]
+        StoreSpeedPolicy,
+        [Display(Name = "Zero Confirmation", Description = "Is unconfirmed")]
+        ZeroConfirmation,
+        [Display(Name = "At Least One", Description = "Has at least 1 confirmation")]
+        AtLeastOne,
+        [Display(Name = "At Least Ten", Description = "Has at least 10 confirmations")]
+        AtLeastTen,
+        [Display(Name = "Custom", Description = "Custom")]
+        Custom
     }
 }

--- a/Plugins/Monero/MoneroPlugin.cs
+++ b/Plugins/Monero/MoneroPlugin.cs
@@ -26,7 +26,7 @@ namespace BTCPayServer.Plugins.Monero;
 
 public class MoneroPlugin : BaseBTCPayServerPlugin
 {
-    public override Version Version => new(1, 3, 4);
+    public override Version Version => new(1, 3, 5);
 
     public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
     [

--- a/Plugins/Monero/Payments/MoneroCheckoutModelExtension.cs
+++ b/Plugins/Monero/Payments/MoneroCheckoutModelExtension.cs
@@ -6,49 +6,48 @@ using BTCPayServer.Payments.Bitcoin;
 using BTCPayServer.Plugins.Monero.Services;
 using BTCPayServer.Services.Invoices;
 
-namespace BTCPayServer.Plugins.Monero.Payments
+namespace BTCPayServer.Plugins.Monero.Payments;
+
+public class MoneroCheckoutModelExtension : ICheckoutModelExtension
 {
-    public class MoneroCheckoutModelExtension : ICheckoutModelExtension
+    private readonly BTCPayNetworkBase _network;
+    private readonly PaymentMethodHandlerDictionary _handlers;
+    private readonly IPaymentLinkExtension paymentLinkExtension;
+
+    public MoneroCheckoutModelExtension(
+        PaymentMethodId paymentMethodId,
+        IEnumerable<IPaymentLinkExtension> paymentLinkExtensions,
+        BTCPayNetworkBase network,
+        PaymentMethodHandlerDictionary handlers)
     {
-        private readonly BTCPayNetworkBase _network;
-        private readonly PaymentMethodHandlerDictionary _handlers;
-        private readonly IPaymentLinkExtension paymentLinkExtension;
+        PaymentMethodId = paymentMethodId;
+        _network = network;
+        _handlers = handlers;
+        paymentLinkExtension = paymentLinkExtensions.Single(p => p.PaymentMethodId == PaymentMethodId);
+    }
+    public PaymentMethodId PaymentMethodId { get; }
 
-        public MoneroCheckoutModelExtension(
-            PaymentMethodId paymentMethodId,
-            IEnumerable<IPaymentLinkExtension> paymentLinkExtensions,
-            BTCPayNetworkBase network,
-            PaymentMethodHandlerDictionary handlers)
+    public string Image => _network.CryptoImagePath;
+    public string Badge => "";
+
+    public void ModifyCheckoutModel(CheckoutModelContext context)
+    {
+        if (context is not { Handler: MoneroLikePaymentMethodHandler handler })
         {
-            PaymentMethodId = paymentMethodId;
-            _network = network;
-            _handlers = handlers;
-            paymentLinkExtension = paymentLinkExtensions.Single(p => p.PaymentMethodId == PaymentMethodId);
+            return;
         }
-        public PaymentMethodId PaymentMethodId { get; }
-
-        public string Image => _network.CryptoImagePath;
-        public string Badge => "";
-
-        public void ModifyCheckoutModel(CheckoutModelContext context)
+        context.Model.CheckoutBodyComponentName = BitcoinCheckoutModelExtension.CheckoutBodyComponentName;
+        var details = context.InvoiceEntity.GetPayments(true)
+                .Select(p => p.GetDetails<MoneroLikePaymentData>(handler))
+                .Where(p => p is not null)
+                .FirstOrDefault();
+        if (details is not null)
         {
-            if (context is not { Handler: MoneroLikePaymentMethodHandler handler })
-            {
-                return;
-            }
-            context.Model.CheckoutBodyComponentName = BitcoinCheckoutModelExtension.CheckoutBodyComponentName;
-            var details = context.InvoiceEntity.GetPayments(true)
-                    .Select(p => p.GetDetails<MoneroLikePaymentData>(handler))
-                    .Where(p => p is not null)
-                    .FirstOrDefault();
-            if (details is not null)
-            {
-                context.Model.ReceivedConfirmations = details.ConfirmationCount;
-                context.Model.RequiredConfirmations = MoneroListener.ConfirmationsRequired(details, context.InvoiceEntity.SpeedPolicy);
-            }
-
-            context.Model.InvoiceBitcoinUrl = paymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper);
-            context.Model.InvoiceBitcoinUrlQR = context.Model.InvoiceBitcoinUrl;
+            context.Model.ReceivedConfirmations = details.ConfirmationCount;
+            context.Model.RequiredConfirmations = MoneroListener.ConfirmationsRequired(details, context.InvoiceEntity.SpeedPolicy);
         }
+
+        context.Model.InvoiceBitcoinUrl = paymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper);
+        context.Model.InvoiceBitcoinUrlQR = context.Model.InvoiceBitcoinUrl;
     }
 }

--- a/Plugins/Monero/Payments/MoneroLikeOnChainPaymentMethodDetails.cs
+++ b/Plugins/Monero/Payments/MoneroLikeOnChainPaymentMethodDetails.cs
@@ -1,9 +1,8 @@
-namespace BTCPayServer.Plugins.Monero.Payments
+namespace BTCPayServer.Plugins.Monero.Payments;
+
+public class MoneroLikeOnChainPaymentMethodDetails
 {
-    public class MoneroLikeOnChainPaymentMethodDetails
-    {
-        public long AccountIndex { get; set; }
-        public uint AddressIndex { get; set; }
-        public int? InvoiceSettledConfirmationThreshold { get; set; }
-    }
+    public long AccountIndex { get; set; }
+    public uint AddressIndex { get; set; }
+    public int? InvoiceSettledConfirmationThreshold { get; set; }
 }

--- a/Plugins/Monero/Payments/MoneroLikePaymentData.cs
+++ b/Plugins/Monero/Payments/MoneroLikePaymentData.cs
@@ -1,13 +1,12 @@
-namespace BTCPayServer.Plugins.Monero.Payments
+namespace BTCPayServer.Plugins.Monero.Payments;
+
+public class MoneroLikePaymentData
 {
-    public class MoneroLikePaymentData
-    {
-        public long SubaddressIndex { get; set; }
-        public long SubaccountIndex { get; set; }
-        public ulong BlockHeight { get; set; }
-        public int ConfirmationCount { get; set; }
-        public string TransactionId { get; set; }
-        public int? InvoiceSettledConfirmationThreshold { get; set; }
-        public int LockTime { get; set; }
-    }
+    public long SubaddressIndex { get; set; }
+    public long SubaccountIndex { get; set; }
+    public ulong BlockHeight { get; set; }
+    public int ConfirmationCount { get; set; }
+    public string TransactionId { get; set; }
+    public int? InvoiceSettledConfirmationThreshold { get; set; }
+    public int LockTime { get; set; }
 }

--- a/Plugins/Monero/Payments/MoneroPaymentLinkExtension.cs
+++ b/Plugins/Monero/Payments/MoneroPaymentLinkExtension.cs
@@ -6,23 +6,22 @@ using BTCPayServer.Services.Invoices;
 
 using Microsoft.AspNetCore.Mvc;
 
-namespace BTCPayServer.Plugins.Monero.Payments
+namespace BTCPayServer.Plugins.Monero.Payments;
+
+public class MoneroPaymentLinkExtension : IPaymentLinkExtension
 {
-    public class MoneroPaymentLinkExtension : IPaymentLinkExtension
+    private readonly MoneroLikeSpecificBtcPayNetwork _network;
+
+    public MoneroPaymentLinkExtension(PaymentMethodId paymentMethodId, MoneroLikeSpecificBtcPayNetwork network)
     {
-        private readonly MoneroLikeSpecificBtcPayNetwork _network;
+        PaymentMethodId = paymentMethodId;
+        _network = network;
+    }
+    public PaymentMethodId PaymentMethodId { get; }
 
-        public MoneroPaymentLinkExtension(PaymentMethodId paymentMethodId, MoneroLikeSpecificBtcPayNetwork network)
-        {
-            PaymentMethodId = paymentMethodId;
-            _network = network;
-        }
-        public PaymentMethodId PaymentMethodId { get; }
-
-        public string? GetPaymentLink(PaymentPrompt prompt, IUrlHelper? urlHelper)
-        {
-            var due = prompt.Calculate().Due;
-            return $"{_network.UriScheme}:{prompt.Destination}?tx_amount={due.ToString(CultureInfo.InvariantCulture)}";
-        }
+    public string? GetPaymentLink(PaymentPrompt prompt, IUrlHelper? urlHelper)
+    {
+        var due = prompt.Calculate().Due;
+        return $"{_network.UriScheme}:{prompt.Destination}?tx_amount={due.ToString(CultureInfo.InvariantCulture)}";
     }
 }

--- a/Plugins/Monero/Payments/MoneroPaymentPromptDetails.cs
+++ b/Plugins/Monero/Payments/MoneroPaymentPromptDetails.cs
@@ -1,8 +1,7 @@
-namespace BTCPayServer.Plugins.Monero.Payments
+namespace BTCPayServer.Plugins.Monero.Payments;
+
+public class MoneroPaymentPromptDetails
 {
-    public class MoneroPaymentPromptDetails
-    {
-        public long AccountIndex { get; set; }
-        public int? InvoiceSettledConfirmationThreshold { get; set; }
-    }
+    public long AccountIndex { get; set; }
+    public int? InvoiceSettledConfirmationThreshold { get; set; }
 }

--- a/Plugins/Monero/Services/MoneroLikeSummaryUpdaterHostedService.cs
+++ b/Plugins/Monero/Services/MoneroLikeSummaryUpdaterHostedService.cs
@@ -8,69 +8,68 @@ using BTCPayServer.Plugins.Monero.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace BTCPayServer.Plugins.Monero.Services
+namespace BTCPayServer.Plugins.Monero.Services;
+
+public class MoneroLikeSummaryUpdaterHostedService : IHostedService
 {
-    public class MoneroLikeSummaryUpdaterHostedService : IHostedService
+    private readonly IMoneroRpcProvider _MoneroRpcProvider;
+    private readonly MoneroLikeConfiguration _moneroLikeConfiguration;
+
+    public Logs Logs { get; }
+
+    private CancellationTokenSource _Cts;
+    public MoneroLikeSummaryUpdaterHostedService(IMoneroRpcProvider moneroRpcProvider, MoneroLikeConfiguration moneroLikeConfiguration, Logs logs)
     {
-        private readonly IMoneroRpcProvider _MoneroRpcProvider;
-        private readonly MoneroLikeConfiguration _moneroLikeConfiguration;
-
-        public Logs Logs { get; }
-
-        private CancellationTokenSource _Cts;
-        public MoneroLikeSummaryUpdaterHostedService(IMoneroRpcProvider moneroRpcProvider, MoneroLikeConfiguration moneroLikeConfiguration, Logs logs)
+        _MoneroRpcProvider = moneroRpcProvider;
+        _moneroLikeConfiguration = moneroLikeConfiguration;
+        Logs = logs;
+    }
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _Cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        foreach (var moneroLikeConfigurationItem in _moneroLikeConfiguration.MoneroLikeConfigurationItems)
         {
-            _MoneroRpcProvider = moneroRpcProvider;
-            _moneroLikeConfiguration = moneroLikeConfiguration;
-            Logs = logs;
+            _ = StartLoop(_Cts.Token, moneroLikeConfigurationItem.Key);
         }
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
-            _Cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            foreach (var moneroLikeConfigurationItem in _moneroLikeConfiguration.MoneroLikeConfigurationItems)
-            {
-                _ = StartLoop(_Cts.Token, moneroLikeConfigurationItem.Key);
-            }
-            return Task.CompletedTask;
-        }
+        return Task.CompletedTask;
+    }
 
-        private async Task StartLoop(CancellationToken cancellation, string cryptoCode)
+    private async Task StartLoop(CancellationToken cancellation, string cryptoCode)
+    {
+        Logs.PayServer.LogInformation($"Starting listening Monero-like daemons ({cryptoCode})");
+        try
         {
-            Logs.PayServer.LogInformation($"Starting listening Monero-like daemons ({cryptoCode})");
-            try
+            while (!cancellation.IsCancellationRequested)
             {
-                while (!cancellation.IsCancellationRequested)
+                try
                 {
-                    try
+                    await _MoneroRpcProvider.UpdateSummary(cryptoCode);
+                    if (_MoneroRpcProvider.IsAvailable(cryptoCode))
                     {
-                        await _MoneroRpcProvider.UpdateSummary(cryptoCode);
-                        if (_MoneroRpcProvider.IsAvailable(cryptoCode))
-                        {
-                            await Task.Delay(TimeSpan.FromMinutes(1), cancellation);
-                        }
-                        else
-                        {
-                            await Task.Delay(TimeSpan.FromSeconds(10), cancellation);
-                        }
+                        await Task.Delay(TimeSpan.FromMinutes(1), cancellation);
                     }
-                    catch (Exception ex) when (!cancellation.IsCancellationRequested)
+                    else
                     {
-                        Logs.PayServer.LogError(ex, $"Unhandled exception in Summary updater ({cryptoCode})");
                         await Task.Delay(TimeSpan.FromSeconds(10), cancellation);
                     }
                 }
-            }
-            catch when (cancellation.IsCancellationRequested)
-            {
-                // ignored
+                catch (Exception ex) when (!cancellation.IsCancellationRequested)
+                {
+                    Logs.PayServer.LogError(ex, $"Unhandled exception in Summary updater ({cryptoCode})");
+                    await Task.Delay(TimeSpan.FromSeconds(10), cancellation);
+                }
             }
         }
-
-        public Task StopAsync(CancellationToken cancellationToken)
+        catch when (cancellation.IsCancellationRequested)
         {
-            _Cts?.Cancel();
-            _Cts?.Dispose();
-            return Task.CompletedTask;
+            // ignored
         }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _Cts?.Cancel();
+        _Cts?.Dispose();
+        return Task.CompletedTask;
     }
 }

--- a/Plugins/Monero/Services/MoneroListener.cs
+++ b/Plugins/Monero/Services/MoneroListener.cs
@@ -23,206 +23,260 @@ using NBitcoin;
 
 using Newtonsoft.Json.Linq;
 
-namespace BTCPayServer.Plugins.Monero.Services
+namespace BTCPayServer.Plugins.Monero.Services;
+
+public class MoneroListener : EventHostedServiceBase
 {
-    public class MoneroListener : EventHostedServiceBase
+    private readonly InvoiceRepository _invoiceRepository;
+    private readonly EventAggregator _eventAggregator;
+    private readonly IMoneroRpcProvider _moneroRpcProvider;
+    private readonly BTCPayNetworkProvider _networkProvider;
+    private readonly ILogger<MoneroListener> _logger;
+    private readonly PaymentMethodHandlerDictionary _handlers;
+    private readonly InvoiceActivator _invoiceActivator;
+    private readonly PaymentService _paymentService;
+
+    public MoneroListener(InvoiceRepository invoiceRepository,
+        EventAggregator eventAggregator,
+        IMoneroRpcProvider moneroRpcProvider,
+        BTCPayNetworkProvider networkProvider,
+        ILogger<MoneroListener> logger,
+        PaymentMethodHandlerDictionary handlers,
+        InvoiceActivator invoiceActivator,
+        PaymentService paymentService) : base(eventAggregator, logger)
     {
-        private readonly InvoiceRepository _invoiceRepository;
-        private readonly EventAggregator _eventAggregator;
-        private readonly IMoneroRpcProvider _moneroRpcProvider;
-        private readonly BTCPayNetworkProvider _networkProvider;
-        private readonly ILogger<MoneroListener> _logger;
-        private readonly PaymentMethodHandlerDictionary _handlers;
-        private readonly InvoiceActivator _invoiceActivator;
-        private readonly PaymentService _paymentService;
+        _invoiceRepository = invoiceRepository;
+        _eventAggregator = eventAggregator;
+        _moneroRpcProvider = moneroRpcProvider;
+        _networkProvider = networkProvider;
+        _logger = logger;
+        _handlers = handlers;
+        _invoiceActivator = invoiceActivator;
+        _paymentService = paymentService;
+    }
 
-        public MoneroListener(InvoiceRepository invoiceRepository,
-            EventAggregator eventAggregator,
-            IMoneroRpcProvider moneroRpcProvider,
-            BTCPayNetworkProvider networkProvider,
-            ILogger<MoneroListener> logger,
-            PaymentMethodHandlerDictionary handlers,
-            InvoiceActivator invoiceActivator,
-            PaymentService paymentService) : base(eventAggregator, logger)
-        {
-            _invoiceRepository = invoiceRepository;
-            _eventAggregator = eventAggregator;
-            _moneroRpcProvider = moneroRpcProvider;
-            _networkProvider = networkProvider;
-            _logger = logger;
-            _handlers = handlers;
-            _invoiceActivator = invoiceActivator;
-            _paymentService = paymentService;
-        }
+    protected override void SubscribeToEvents()
+    {
+        base.SubscribeToEvents();
+        Subscribe<MoneroEvent>();
+        Subscribe<MoneroRpcProvider.MoneroDaemonStateChange>();
+    }
 
-        protected override void SubscribeToEvents()
+    protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
+    {
+        if (evt is MoneroRpcProvider.MoneroDaemonStateChange stateChange)
         {
-            base.SubscribeToEvents();
-            Subscribe<MoneroEvent>();
-            Subscribe<MoneroRpcProvider.MoneroDaemonStateChange>();
-        }
-
-        protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
-        {
-            if (evt is MoneroRpcProvider.MoneroDaemonStateChange stateChange)
+            if (_moneroRpcProvider.IsAvailable(stateChange.CryptoCode))
             {
-                if (_moneroRpcProvider.IsAvailable(stateChange.CryptoCode))
-                {
-                    _logger.LogInformation($"{stateChange.CryptoCode} just became available");
-                    _ = UpdateAnyPendingMoneroLikePayment(stateChange.CryptoCode);
-                }
-                else
-                {
-                    _logger.LogInformation($"{stateChange.CryptoCode} just became unavailable");
-                }
+                _logger.LogInformation($"{stateChange.CryptoCode} just became available");
+                _ = UpdateAnyPendingMoneroLikePayment(stateChange.CryptoCode);
             }
-            else if (evt is MoneroEvent moneroEvent)
+            else
             {
-                if (!_moneroRpcProvider.IsAvailable(moneroEvent.CryptoCode))
-                {
-                    return;
-                }
-
-                if (!string.IsNullOrEmpty(moneroEvent.BlockHash))
-                {
-                    await OnNewBlock(moneroEvent.CryptoCode);
-                }
-
-                if (!string.IsNullOrEmpty(moneroEvent.TransactionHash))
-                {
-                    await OnTransactionUpdated(moneroEvent.CryptoCode, moneroEvent.TransactionHash);
-                }
+                _logger.LogInformation($"{stateChange.CryptoCode} just became unavailable");
             }
         }
-
-        private async Task ReceivedPayment(InvoiceEntity invoice, PaymentEntity payment)
+        else if (evt is MoneroEvent moneroEvent)
         {
-            _logger.LogInformation(
-                $"Invoice {invoice.Id} received payment {payment.Value} {payment.Currency} {payment.Id}");
-
-            var prompt = invoice.GetPaymentPrompt(payment.PaymentMethodId);
-
-            if (prompt != null &&
-                prompt.Activated &&
-                prompt.Destination == payment.Destination &&
-                prompt.Calculate().Due > 0.0m)
-            {
-                await _invoiceActivator.ActivateInvoicePaymentMethod(invoice.Id, payment.PaymentMethodId, true);
-                invoice = await _invoiceRepository.GetInvoice(invoice.Id);
-            }
-
-            _eventAggregator.Publish(
-                new InvoiceEvent(invoice, InvoiceEvent.ReceivedPayment) { Payment = payment });
-        }
-
-        private async Task UpdatePaymentStates(string cryptoCode, InvoiceEntity[] invoices)
-        {
-            if (!invoices.Any())
+            if (!_moneroRpcProvider.IsAvailable(moneroEvent.CryptoCode))
             {
                 return;
             }
 
-            var moneroWalletRpcClient = _moneroRpcProvider.WalletRpcClients[cryptoCode];
-            var network = _networkProvider.GetNetwork(cryptoCode);
-            var paymentId = PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode);
-            var handler = (MoneroLikePaymentMethodHandler)_handlers[paymentId];
-
-            //get all the required data in one list (invoice, its existing payments and the current payment method details)
-            var expandedInvoices = invoices.Select(entity => (Invoice: entity,
-                    ExistingPayments: GetAllMoneroLikePayments(entity, cryptoCode),
-                    Prompt: entity.GetPaymentPrompt(paymentId),
-                    PaymentMethodDetails: handler.ParsePaymentPromptDetails(entity.GetPaymentPrompt(paymentId)
-                        .Details)))
-                .Select(tuple => (
-                    tuple.Invoice,
-                    tuple.PaymentMethodDetails,
-                    tuple.Prompt,
-                    ExistingPayments: tuple.ExistingPayments.Select(entity =>
-                        (Payment: entity, PaymentData: handler.ParsePaymentDetails(entity.Details),
-                            tuple.Invoice))
-                ));
-
-            var existingPaymentData = expandedInvoices.SelectMany(tuple => tuple.ExistingPayments);
-
-            var accountToAddressQuery = new Dictionary<long, List<long>>();
-            //create list of subaddresses to account to query the monero wallet
-            foreach (var expandedInvoice in expandedInvoices)
+            if (!string.IsNullOrEmpty(moneroEvent.BlockHash))
             {
-                foreach (var existingPayment in expandedInvoice.ExistingPayments)
-                {
-                    long paymentAccountIndex = existingPayment.PaymentData.SubaccountIndex;
-                    List<long> subaddressIndicesForAccount = accountToAddressQuery.GetValueOrDefault(paymentAccountIndex, []);
-                    subaddressIndicesForAccount.Add(existingPayment.PaymentData.SubaddressIndex);
-                    accountToAddressQuery.AddOrReplace(paymentAccountIndex, subaddressIndicesForAccount);
-                }
-
-                // add the current address for pending/unpaid balance
-                long currentAccountIndex = expandedInvoice.PaymentMethodDetails.AccountIndex;
-                List<long> subaddressIndicesForCurrentAccount = accountToAddressQuery.GetValueOrDefault(currentAccountIndex, []);
-                subaddressIndicesForCurrentAccount.Add(expandedInvoice.PaymentMethodDetails.AddressIndex);
-                accountToAddressQuery.AddOrReplace(currentAccountIndex, subaddressIndicesForCurrentAccount);
+                await OnNewBlock(moneroEvent.CryptoCode);
             }
 
-            var tasks = accountToAddressQuery.ToDictionary(datas => datas.Key,
-                datas => moneroWalletRpcClient.SendCommandAsync<GetTransfersRequest, GetTransfersResponse>(
-                    "get_transfers",
-                    new GetTransfersRequest
-                    {
-                        AccountIndex = datas.Key,
-                        In = true,
-                        SubaddrIndices = datas.Value.Distinct().ToList()
-                    }));
-
-            await Task.WhenAll(tasks.Values);
-
-
-            var transferProcessingTasks = new List<Task>();
-
-            var updatedPaymentEntities = new List<(PaymentEntity Payment, InvoiceEntity invoice)>();
-            foreach (var keyValuePair in tasks)
+            if (!string.IsNullOrEmpty(moneroEvent.TransactionHash))
             {
-                var transfers = keyValuePair.Value.Result.IncomingTransfers;
-                if (transfers == null)
+                await OnTransactionUpdated(moneroEvent.CryptoCode, moneroEvent.TransactionHash);
+            }
+        }
+    }
+
+    private async Task ReceivedPayment(InvoiceEntity invoice, PaymentEntity payment)
+    {
+        _logger.LogInformation(
+            $"Invoice {invoice.Id} received payment {payment.Value} {payment.Currency} {payment.Id}");
+
+        var prompt = invoice.GetPaymentPrompt(payment.PaymentMethodId);
+
+        if (prompt != null &&
+            prompt.Activated &&
+            prompt.Destination == payment.Destination &&
+            prompt.Calculate().Due > 0.0m)
+        {
+            await _invoiceActivator.ActivateInvoicePaymentMethod(invoice.Id, payment.PaymentMethodId, true);
+            invoice = await _invoiceRepository.GetInvoice(invoice.Id);
+        }
+
+        _eventAggregator.Publish(
+            new InvoiceEvent(invoice, InvoiceEvent.ReceivedPayment) { Payment = payment });
+    }
+
+    private async Task UpdatePaymentStates(string cryptoCode, InvoiceEntity[] invoices)
+    {
+        if (!invoices.Any())
+        {
+            return;
+        }
+
+        var moneroWalletRpcClient = _moneroRpcProvider.WalletRpcClients[cryptoCode];
+        var network = _networkProvider.GetNetwork(cryptoCode);
+        var paymentId = PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode);
+        var handler = (MoneroLikePaymentMethodHandler)_handlers[paymentId];
+
+        //get all the required data in one list (invoice, its existing payments and the current payment method details)
+        var expandedInvoices = invoices.Select(entity => (Invoice: entity,
+                ExistingPayments: GetAllMoneroLikePayments(entity, cryptoCode),
+                Prompt: entity.GetPaymentPrompt(paymentId),
+                PaymentMethodDetails: handler.ParsePaymentPromptDetails(entity.GetPaymentPrompt(paymentId)
+                    .Details)))
+            .Select(tuple => (
+                tuple.Invoice,
+                tuple.PaymentMethodDetails,
+                tuple.Prompt,
+                ExistingPayments: tuple.ExistingPayments.Select(entity =>
+                    (Payment: entity, PaymentData: handler.ParsePaymentDetails(entity.Details),
+                        tuple.Invoice))
+            ));
+
+        var existingPaymentData = expandedInvoices.SelectMany(tuple => tuple.ExistingPayments);
+
+        var accountToAddressQuery = new Dictionary<long, List<long>>();
+        //create list of subaddresses to account to query the monero wallet
+        foreach (var expandedInvoice in expandedInvoices)
+        {
+            foreach (var existingPayment in expandedInvoice.ExistingPayments)
+            {
+                long paymentAccountIndex = existingPayment.PaymentData.SubaccountIndex;
+                List<long> subaddressIndicesForAccount = accountToAddressQuery.GetValueOrDefault(paymentAccountIndex, []);
+                subaddressIndicesForAccount.Add(existingPayment.PaymentData.SubaddressIndex);
+                accountToAddressQuery.AddOrReplace(paymentAccountIndex, subaddressIndicesForAccount);
+            }
+
+            // add the current address for pending/unpaid balance
+            long currentAccountIndex = expandedInvoice.PaymentMethodDetails.AccountIndex;
+            List<long> subaddressIndicesForCurrentAccount = accountToAddressQuery.GetValueOrDefault(currentAccountIndex, []);
+            subaddressIndicesForCurrentAccount.Add(expandedInvoice.PaymentMethodDetails.AddressIndex);
+            accountToAddressQuery.AddOrReplace(currentAccountIndex, subaddressIndicesForCurrentAccount);
+        }
+
+        var tasks = accountToAddressQuery.ToDictionary(datas => datas.Key,
+            datas => moneroWalletRpcClient.SendCommandAsync<GetTransfersRequest, GetTransfersResponse>(
+                "get_transfers",
+                new GetTransfersRequest
                 {
-                    continue;
-                }
-
-                transferProcessingTasks.AddRange(transfers.Select(transfer =>
-                {
-                    InvoiceEntity invoice = null;
-                    var existingMatch = existingPaymentData.SingleOrDefault(tuple =>
-                        tuple.Payment.Destination == transfer.Address &&
-                        tuple.PaymentData.TransactionId == transfer.TransactionId);
-
-                    if (existingMatch.Invoice != null)
-                    {
-                        invoice = existingMatch.Invoice;
-                    }
-                    else
-                    {
-                        var newMatch = expandedInvoices.SingleOrDefault(tuple =>
-                            tuple.Prompt.Destination == transfer.Address);
-
-                        if (newMatch.Invoice == null)
-                        {
-                            return Task.CompletedTask;
-                        }
-
-                        invoice = newMatch.Invoice;
-                    }
-
-
-                    return HandlePaymentData(cryptoCode, transfer.Address, transfer.Amount, transfer.SubaddressIndex.AccountIndex,
-                        transfer.SubaddressIndex.Index, transfer.TransactionId, transfer.Confirmations, transfer.Height,
-                        transfer.UnlockTime, invoice,
-                        updatedPaymentEntities);
+                    AccountIndex = datas.Key,
+                    In = true,
+                    SubaddrIndices = datas.Value.Distinct().ToList()
                 }));
+
+        await Task.WhenAll(tasks.Values);
+
+
+        var transferProcessingTasks = new List<Task>();
+
+        var updatedPaymentEntities = new List<(PaymentEntity Payment, InvoiceEntity invoice)>();
+        foreach (var keyValuePair in tasks)
+        {
+            var transfers = keyValuePair.Value.Result.IncomingTransfers;
+            if (transfers == null)
+            {
+                continue;
             }
 
-            transferProcessingTasks.Add(
-                _paymentService.UpdatePayments(updatedPaymentEntities.Select(tuple => tuple.Item1).ToList()));
-            await Task.WhenAll(transferProcessingTasks);
-            foreach (var valueTuples in updatedPaymentEntities.GroupBy(entity => entity.Item2))
+            transferProcessingTasks.AddRange(transfers.Select(transfer =>
+            {
+                InvoiceEntity invoice = null;
+                var existingMatch = existingPaymentData.SingleOrDefault(tuple =>
+                    tuple.Payment.Destination == transfer.Address &&
+                    tuple.PaymentData.TransactionId == transfer.TransactionId);
+
+                if (existingMatch.Invoice != null)
+                {
+                    invoice = existingMatch.Invoice;
+                }
+                else
+                {
+                    var newMatch = expandedInvoices.SingleOrDefault(tuple =>
+                        tuple.Prompt.Destination == transfer.Address);
+
+                    if (newMatch.Invoice == null)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    invoice = newMatch.Invoice;
+                }
+
+
+                return HandlePaymentData(cryptoCode, transfer.Address, transfer.Amount, transfer.SubaddressIndex.AccountIndex,
+                    transfer.SubaddressIndex.Index, transfer.TransactionId, transfer.Confirmations, transfer.Height,
+                    transfer.UnlockTime, invoice,
+                    updatedPaymentEntities);
+            }));
+        }
+
+        transferProcessingTasks.Add(
+            _paymentService.UpdatePayments(updatedPaymentEntities.Select(tuple => tuple.Item1).ToList()));
+        await Task.WhenAll(transferProcessingTasks);
+        foreach (var valueTuples in updatedPaymentEntities.GroupBy(entity => entity.Item2))
+        {
+            if (valueTuples.Any())
+            {
+                _eventAggregator.Publish(new InvoiceNeedUpdateEvent(valueTuples.Key.Id));
+            }
+        }
+    }
+
+    private async Task OnNewBlock(string cryptoCode)
+    {
+        await UpdateAnyPendingMoneroLikePayment(cryptoCode);
+        _eventAggregator.Publish(new NewBlockEvent()
+        { PaymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode) });
+    }
+
+    private async Task OnTransactionUpdated(string cryptoCode, string transactionHash)
+    {
+        var paymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
+        var transfer = await GetTransferByTxId(cryptoCode, transactionHash, this.CancellationToken);
+        if (transfer is null)
+        {
+            return;
+        }
+        var paymentsToUpdate = new List<(PaymentEntity Payment, InvoiceEntity invoice)>();
+
+        //group all destinations of the tx together and loop through the sets
+        foreach (var destination in transfer.Transfers.GroupBy(destination => destination.Address))
+        {
+            //find the invoice corresponding to this address, else skip
+            var invoice = await _invoiceRepository.GetInvoiceFromAddress(paymentMethodId, destination.Key);
+            if (invoice == null)
+            {
+                continue;
+            }
+
+            var index = destination.First().SubaddressIndex;
+
+            await HandlePaymentData(cryptoCode,
+                destination.Key,
+                destination.Sum(destination1 => destination1.Amount),
+                index.AccountIndex,
+                index.Index,
+                transfer.Transfer.TransactionId,
+                transfer.Transfer.Confirmations,
+                transfer.Transfer.Height,
+                transfer.Transfer.UnlockTime,
+                invoice,
+                paymentsToUpdate);
+        }
+
+        if (paymentsToUpdate.Any())
+        {
+            await _paymentService.UpdatePayments(paymentsToUpdate.Select(tuple => tuple.Payment).ToList());
+            foreach (var valueTuples in paymentsToUpdate.GroupBy(entity => entity.invoice))
             {
                 if (valueTuples.Any())
                 {
@@ -230,205 +284,150 @@ namespace BTCPayServer.Plugins.Monero.Services
                 }
             }
         }
+    }
 
-        private async Task OnNewBlock(string cryptoCode)
+    private async Task<GetTransferByTransactionIdResponse> GetTransferByTxId(string cryptoCode,
+        string transactionHash, CancellationToken cancellationToken)
+    {
+        var accounts = await _moneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GetAccountsRequest, GetAccountsResponse>("get_accounts", new GetAccountsRequest(), cancellationToken);
+        var accountIndexes = accounts
+            .Accounts
+            .Select(a => a.AccountIndex)
+            .ToList();
+        if (accountIndexes.Count is 0)
         {
-            await UpdateAnyPendingMoneroLikePayment(cryptoCode);
-            _eventAggregator.Publish(new NewBlockEvent()
-            { PaymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode) });
+            accountIndexes.Add(null);
         }
-
-        private async Task OnTransactionUpdated(string cryptoCode, string transactionHash)
+        var req = accountIndexes
+            .Select(i => GetTransferByTxId(cryptoCode, transactionHash, i))
+            .ToArray();
+        foreach (var task in req)
         {
-            var paymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
-            var transfer = await GetTransferByTxId(cryptoCode, transactionHash, this.CancellationToken);
-            if (transfer is null)
+            var result = await task;
+            if (result != null)
             {
-                return;
-            }
-            var paymentsToUpdate = new List<(PaymentEntity Payment, InvoiceEntity invoice)>();
-
-            //group all destinations of the tx together and loop through the sets
-            foreach (var destination in transfer.Transfers.GroupBy(destination => destination.Address))
-            {
-                //find the invoice corresponding to this address, else skip
-                var invoice = await _invoiceRepository.GetInvoiceFromAddress(paymentMethodId, destination.Key);
-                if (invoice == null)
-                {
-                    continue;
-                }
-
-                var index = destination.First().SubaddressIndex;
-
-                await HandlePaymentData(cryptoCode,
-                    destination.Key,
-                    destination.Sum(destination1 => destination1.Amount),
-                    index.AccountIndex,
-                    index.Index,
-                    transfer.Transfer.TransactionId,
-                    transfer.Transfer.Confirmations,
-                    transfer.Transfer.Height,
-                    transfer.Transfer.UnlockTime,
-                    invoice,
-                    paymentsToUpdate);
-            }
-
-            if (paymentsToUpdate.Any())
-            {
-                await _paymentService.UpdatePayments(paymentsToUpdate.Select(tuple => tuple.Payment).ToList());
-                foreach (var valueTuples in paymentsToUpdate.GroupBy(entity => entity.invoice))
-                {
-                    if (valueTuples.Any())
-                    {
-                        _eventAggregator.Publish(new InvoiceNeedUpdateEvent(valueTuples.Key.Id));
-                    }
-                }
-            }
-        }
-
-        private async Task<GetTransferByTransactionIdResponse> GetTransferByTxId(string cryptoCode,
-            string transactionHash, CancellationToken cancellationToken)
-        {
-            var accounts = await _moneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GetAccountsRequest, GetAccountsResponse>("get_accounts", new GetAccountsRequest(), cancellationToken);
-            var accountIndexes = accounts
-                .Accounts
-                .Select(a => a.AccountIndex)
-                .ToList();
-            if (accountIndexes.Count is 0)
-            {
-                accountIndexes.Add(null);
-            }
-            var req = accountIndexes
-                .Select(i => GetTransferByTxId(cryptoCode, transactionHash, i))
-                .ToArray();
-            foreach (var task in req)
-            {
-                var result = await task;
-                if (result != null)
-                {
-                    return result;
-                }
-            }
-
-            return null;
-        }
-
-        private async Task<GetTransferByTransactionIdResponse> GetTransferByTxId(string cryptoCode, string transactionHash, long? accountIndex)
-        {
-            try
-            {
-                var result = await _moneroRpcProvider.WalletRpcClients[cryptoCode]
-                    .SendCommandAsync<GetTransferByTransactionIdRequest, GetTransferByTransactionIdResponse>(
-                        "get_transfer_by_txid",
-                        new GetTransferByTransactionIdRequest
-                        {
-                            TransactionId = transactionHash,
-                            AccountIndex = accountIndex
-                        });
                 return result;
             }
-            catch (JsonRpcApiException)
-            {
-                return null;
-            }
         }
 
-        private async Task HandlePaymentData(string cryptoCode, string address, long totalAmount, uint subaccountIndex,
-            uint subaddressIndex,
-            string txId, int confirmations, ulong blockHeight, int locktime, InvoiceEntity invoice,
-            List<(PaymentEntity Payment, InvoiceEntity invoice)> paymentsToUpdate)
+        return null;
+    }
+
+    private async Task<GetTransferByTransactionIdResponse> GetTransferByTxId(string cryptoCode, string transactionHash, long? accountIndex)
+    {
+        try
         {
-            var network = _networkProvider.GetNetwork(cryptoCode);
-            var pmi = PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode);
-            var handler = (MoneroLikePaymentMethodHandler)_handlers[pmi];
-            var promptDetails = handler.ParsePaymentPromptDetails(invoice.GetPaymentPrompt(pmi).Details);
-            var details = new MoneroLikePaymentData
-            {
-                SubaccountIndex = subaccountIndex,
-                SubaddressIndex = subaddressIndex,
-                TransactionId = txId,
-                ConfirmationCount = confirmations,
-                BlockHeight = blockHeight,
-                LockTime = locktime,
-                InvoiceSettledConfirmationThreshold = promptDetails.InvoiceSettledConfirmationThreshold
-            };
-
-            // set destination address from transfer
-            var prompt = invoice.GetPaymentPrompt(pmi);
-            if (prompt != null && prompt.Destination != address)
-            {
-                prompt.Destination = address;
-                await _invoiceRepository.UpdatePrompt(invoice.Id, prompt, [address]);
-                invoice = await _invoiceRepository.GetInvoice(invoice.Id);
-            }
-
-            var status = GetStatus(details, invoice.SpeedPolicy) ? PaymentStatus.Settled : PaymentStatus.Processing;
-            var paymentData = new PaymentData
-            {
-                Status = status,
-                Amount = MoneroMoney.Convert(totalAmount),
-                Created = DateTimeOffset.UtcNow,
-                Id = $"{txId}#{subaccountIndex}#{subaddressIndex}",
-                Currency = network.CryptoCode,
-                InvoiceDataId = invoice.Id,
-            }.Set(invoice, handler, details);
-
-
-            //check if this tx exists as a payment to this invoice already
-            var alreadyExistingPaymentThatMatches = GetAllMoneroLikePayments(invoice, cryptoCode)
-                .SingleOrDefault(c => c.Id == paymentData.Id && c.PaymentMethodId == pmi);
-
-            //if it doesnt, add it and assign a new monerolike address to the system if a balance is still due
-            if (alreadyExistingPaymentThatMatches == null)
-            {
-                var payment = await _paymentService.AddPayment(paymentData, [txId]);
-                if (payment != null)
-                {
-                    await ReceivedPayment(invoice, payment);
-                }
-            }
-            else
-            {
-                //else update it with the new data
-                alreadyExistingPaymentThatMatches.Status = status;
-                alreadyExistingPaymentThatMatches.Details = JToken.FromObject(details, handler.Serializer);
-                paymentsToUpdate.Add((alreadyExistingPaymentThatMatches, invoice));
-            }
+            var result = await _moneroRpcProvider.WalletRpcClients[cryptoCode]
+                .SendCommandAsync<GetTransferByTransactionIdRequest, GetTransferByTransactionIdResponse>(
+                    "get_transfer_by_txid",
+                    new GetTransferByTransactionIdRequest
+                    {
+                        TransactionId = transactionHash,
+                        AccountIndex = accountIndex
+                    });
+            return result;
         }
-
-        private bool GetStatus(MoneroLikePaymentData details, SpeedPolicy speedPolicy)
-            => ConfirmationsRequired(details, speedPolicy) <= details.ConfirmationCount;
-
-        public static int ConfirmationsRequired(MoneroLikePaymentData details, SpeedPolicy speedPolicy)
-            => (details, speedPolicy) switch
-            {
-                (_, _) when details.ConfirmationCount < details.LockTime =>
-                    details.LockTime - details.ConfirmationCount,
-                ({ InvoiceSettledConfirmationThreshold: int v }, _) => v,
-                (_, SpeedPolicy.HighSpeed) => 0,
-                (_, SpeedPolicy.MediumSpeed) => 1,
-                (_, SpeedPolicy.LowMediumSpeed) => 2,
-                (_, SpeedPolicy.LowSpeed) => 6,
-                _ => 6,
-            };
-
-
-        private async Task UpdateAnyPendingMoneroLikePayment(string cryptoCode)
+        catch (JsonRpcApiException)
         {
-            var paymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
-            var invoices = await _invoiceRepository.GetMonitoredInvoices(paymentMethodId);
-            if (!invoices.Any())
-            {
-                return;
-            }
-            invoices = invoices.Where(entity => entity.GetPaymentPrompt(paymentMethodId)?.Activated is true).ToArray();
-            await UpdatePaymentStates(cryptoCode, invoices);
+            return null;
+        }
+    }
+
+    private async Task HandlePaymentData(string cryptoCode, string address, long totalAmount, uint subaccountIndex,
+        uint subaddressIndex,
+        string txId, int confirmations, ulong blockHeight, int locktime, InvoiceEntity invoice,
+        List<(PaymentEntity Payment, InvoiceEntity invoice)> paymentsToUpdate)
+    {
+        var network = _networkProvider.GetNetwork(cryptoCode);
+        var pmi = PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode);
+        var handler = (MoneroLikePaymentMethodHandler)_handlers[pmi];
+        var promptDetails = handler.ParsePaymentPromptDetails(invoice.GetPaymentPrompt(pmi).Details);
+        var details = new MoneroLikePaymentData
+        {
+            SubaccountIndex = subaccountIndex,
+            SubaddressIndex = subaddressIndex,
+            TransactionId = txId,
+            ConfirmationCount = confirmations,
+            BlockHeight = blockHeight,
+            LockTime = locktime,
+            InvoiceSettledConfirmationThreshold = promptDetails.InvoiceSettledConfirmationThreshold
+        };
+
+        // set destination address from transfer
+        var prompt = invoice.GetPaymentPrompt(pmi);
+        if (prompt != null && prompt.Destination != address)
+        {
+            prompt.Destination = address;
+            await _invoiceRepository.UpdatePrompt(invoice.Id, prompt, [address]);
+            invoice = await _invoiceRepository.GetInvoice(invoice.Id);
         }
 
-        private IEnumerable<PaymentEntity> GetAllMoneroLikePayments(InvoiceEntity invoice, string cryptoCode)
+        var status = GetStatus(details, invoice.SpeedPolicy) ? PaymentStatus.Settled : PaymentStatus.Processing;
+        var paymentData = new PaymentData
         {
-            return invoice.GetPayments(false)
-                .Where(p => p.PaymentMethodId == PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode));
+            Status = status,
+            Amount = MoneroMoney.Convert(totalAmount),
+            Created = DateTimeOffset.UtcNow,
+            Id = $"{txId}#{subaccountIndex}#{subaddressIndex}",
+            Currency = network.CryptoCode,
+            InvoiceDataId = invoice.Id,
+        }.Set(invoice, handler, details);
+
+
+        //check if this tx exists as a payment to this invoice already
+        var alreadyExistingPaymentThatMatches = GetAllMoneroLikePayments(invoice, cryptoCode)
+            .SingleOrDefault(c => c.Id == paymentData.Id && c.PaymentMethodId == pmi);
+
+        //if it doesnt, add it and assign a new monerolike address to the system if a balance is still due
+        if (alreadyExistingPaymentThatMatches == null)
+        {
+            var payment = await _paymentService.AddPayment(paymentData, [txId]);
+            if (payment != null)
+            {
+                await ReceivedPayment(invoice, payment);
+            }
         }
+        else
+        {
+            //else update it with the new data
+            alreadyExistingPaymentThatMatches.Status = status;
+            alreadyExistingPaymentThatMatches.Details = JToken.FromObject(details, handler.Serializer);
+            paymentsToUpdate.Add((alreadyExistingPaymentThatMatches, invoice));
+        }
+    }
+
+    private bool GetStatus(MoneroLikePaymentData details, SpeedPolicy speedPolicy)
+        => ConfirmationsRequired(details, speedPolicy) <= details.ConfirmationCount;
+
+    public static int ConfirmationsRequired(MoneroLikePaymentData details, SpeedPolicy speedPolicy)
+        => (details, speedPolicy) switch
+        {
+            (_, _) when details.ConfirmationCount < details.LockTime =>
+                details.LockTime - details.ConfirmationCount,
+            ({ InvoiceSettledConfirmationThreshold: int v }, _) => v,
+            (_, SpeedPolicy.HighSpeed) => 0,
+            (_, SpeedPolicy.MediumSpeed) => 1,
+            (_, SpeedPolicy.LowMediumSpeed) => 2,
+            (_, SpeedPolicy.LowSpeed) => 6,
+            _ => 6,
+        };
+
+
+    private async Task UpdateAnyPendingMoneroLikePayment(string cryptoCode)
+    {
+        var paymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
+        var invoices = await _invoiceRepository.GetMonitoredInvoices(paymentMethodId);
+        if (!invoices.Any())
+        {
+            return;
+        }
+        invoices = invoices.Where(entity => entity.GetPaymentPrompt(paymentMethodId)?.Activated is true).ToArray();
+        await UpdatePaymentStates(cryptoCode, invoices);
+    }
+
+    private IEnumerable<PaymentEntity> GetAllMoneroLikePayments(InvoiceEntity invoice, string cryptoCode)
+    {
+        return invoice.GetPayments(false)
+            .Where(p => p.PaymentMethodId == PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode));
     }
 }

--- a/Plugins/Monero/Services/MoneroSyncSummaryProvider.cs
+++ b/Plugins/Monero/Services/MoneroSyncSummaryProvider.cs
@@ -5,43 +5,42 @@ using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Payments;
 
-namespace BTCPayServer.Plugins.Monero.Services
+namespace BTCPayServer.Plugins.Monero.Services;
+
+public class MoneroSyncSummaryProvider : ISyncSummaryProvider
 {
-    public class MoneroSyncSummaryProvider : ISyncSummaryProvider
+    private readonly IMoneroRpcProvider _moneroRpcProvider;
+
+    public MoneroSyncSummaryProvider(IMoneroRpcProvider moneroRpcProvider)
     {
-        private readonly IMoneroRpcProvider _moneroRpcProvider;
+        _moneroRpcProvider = moneroRpcProvider;
+    }
 
-        public MoneroSyncSummaryProvider(IMoneroRpcProvider moneroRpcProvider)
-        {
-            _moneroRpcProvider = moneroRpcProvider;
-        }
+    public bool AllAvailable()
+    {
+        return _moneroRpcProvider.Summaries.All(pair => pair.Value.DaemonAvailable);
+    }
 
-        public bool AllAvailable()
+    public string Partial { get; } = "/Views/Monero/MoneroSyncSummary.cshtml";
+    public IEnumerable<ISyncStatus> GetStatuses()
+    {
+        return _moneroRpcProvider.Summaries.Select(pair => new MoneroSyncStatus()
         {
-            return _moneroRpcProvider.Summaries.All(pair => pair.Value.DaemonAvailable);
-        }
+            Summary = pair.Value,
+            PaymentMethodId = PaymentMethodId.Parse(pair.Key).ToString()
+        });
+    }
+}
 
-        public string Partial { get; } = "/Views/Monero/MoneroSyncSummary.cshtml";
-        public IEnumerable<ISyncStatus> GetStatuses()
+public class MoneroSyncStatus : SyncStatus, ISyncStatus
+{
+    public override bool Available
+    {
+        get
         {
-            return _moneroRpcProvider.Summaries.Select(pair => new MoneroSyncStatus()
-            {
-                Summary = pair.Value,
-                PaymentMethodId = PaymentMethodId.Parse(pair.Key).ToString()
-            });
+            return Summary?.WalletAvailable ?? false;
         }
     }
 
-    public class MoneroSyncStatus : SyncStatus, ISyncStatus
-    {
-        public override bool Available
-        {
-            get
-            {
-                return Summary?.WalletAvailable ?? false;
-            }
-        }
-
-        public MoneroRpcProvider.MoneroLikeSummary Summary { get; set; }
-    }
+    public MoneroRpcProvider.MoneroLikeSummary Summary { get; set; }
 }

--- a/Plugins/Monero/Utils/MoneroMoney.cs
+++ b/Plugins/Monero/Utils/MoneroMoney.cs
@@ -1,20 +1,19 @@
 using System.Globalization;
 
-namespace BTCPayServer.Plugins.Monero.Utils
+namespace BTCPayServer.Plugins.Monero.Utils;
+
+public static class MoneroMoney
 {
-    public static class MoneroMoney
+    public static decimal Convert(long piconero)
     {
-        public static decimal Convert(long piconero)
-        {
-            var amt = piconero.ToString(CultureInfo.InvariantCulture).PadLeft(12, '0');
-            amt = amt.Length == 12 ? $"0.{amt}" : amt.Insert(amt.Length - 12, ".");
+        var amt = piconero.ToString(CultureInfo.InvariantCulture).PadLeft(12, '0');
+        amt = amt.Length == 12 ? $"0.{amt}" : amt.Insert(amt.Length - 12, ".");
 
-            return decimal.Parse(amt, CultureInfo.InvariantCulture);
-        }
+        return decimal.Parse(amt, CultureInfo.InvariantCulture);
+    }
 
-        public static long Convert(decimal monero)
-        {
-            return System.Convert.ToInt64(monero * 1000000000000);
-        }
+    public static long Convert(decimal monero)
+    {
+        return System.Convert.ToInt64(monero * 1000000000000);
     }
 }

--- a/Plugins/Monero/ViewModels/MoneroPaymentViewModel.cs
+++ b/Plugins/Monero/ViewModels/MoneroPaymentViewModel.cs
@@ -2,17 +2,16 @@ using System;
 
 using BTCPayServer.Payments;
 
-namespace BTCPayServer.Plugins.Monero.ViewModels
+namespace BTCPayServer.Plugins.Monero.ViewModels;
+
+public class MoneroPaymentViewModel
 {
-    public class MoneroPaymentViewModel
-    {
-        public PaymentMethodId PaymentMethodId { get; set; }
-        public string Confirmations { get; set; }
-        public string DepositAddress { get; set; }
-        public string Amount { get; set; }
-        public string TransactionId { get; set; }
-        public DateTimeOffset ReceivedTime { get; set; }
-        public string TransactionLink { get; set; }
-        public string Currency { get; set; }
-    }
+    public PaymentMethodId PaymentMethodId { get; set; }
+    public string Confirmations { get; set; }
+    public string DepositAddress { get; set; }
+    public string Amount { get; set; }
+    public string TransactionId { get; set; }
+    public DateTimeOffset ReceivedTime { get; set; }
+    public string TransactionLink { get; set; }
+    public string Currency { get; set; }
 }

--- a/Plugins/Monero/Views/Monero/MoneroSyncSummary.cshtml
+++ b/Plugins/Monero/Views/Monero/MoneroSyncSummary.cshtml
@@ -1,5 +1,5 @@
 @using BTCPayServer.Plugins.Monero.Services
-@inject MoneroRpcProvider MoneroRpcProvider
+@inject IMoneroRpcProvider MoneroRpcProvider
 @inject SignInManager<ApplicationUser> SignInManager;
 
 @if (SignInManager.IsSignedIn(User) && User.IsInRole(Roles.ServerAdmin) && MoneroRpcProvider.Summaries.Any())


### PR DESCRIPTION
fixes https://github.com/btcpay-monero/btcpayserver-monero-plugin/issues/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the Monero synchronization summary’s provider integration without changing the visible functionality.
  * Node and wallet synchronization details continue to be displayed as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->