### PR TITLE
Use atomic write to prevent race exception

### DIFF
--- a/Plugins/Monero/Services/MoneroListener.cs
+++ b/Plugins/Monero/Services/MoneroListener.cs
@@ -19,8 +19,6 @@ using Microsoft.Extensions.Logging;
 using Monero.Common;
 using Monero.Wallet.Rpc;
 
-using NBitcoin;
-
 using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Plugins.Monero.Services;
@@ -153,14 +151,14 @@ public class MoneroListener : EventHostedServiceBase
                 long paymentAccountIndex = existingPayment.PaymentData.SubaccountIndex;
                 List<long> subaddressIndicesForAccount = accountToAddressQuery.GetValueOrDefault(paymentAccountIndex, []);
                 subaddressIndicesForAccount.Add(existingPayment.PaymentData.SubaddressIndex);
-                accountToAddressQuery.AddOrReplace(paymentAccountIndex, subaddressIndicesForAccount);
+                accountToAddressQuery[paymentAccountIndex] = subaddressIndicesForAccount;
             }
 
             // add the current address for pending/unpaid balance
             long currentAccountIndex = expandedInvoice.PaymentMethodDetails.AccountIndex;
             List<long> subaddressIndicesForCurrentAccount = accountToAddressQuery.GetValueOrDefault(currentAccountIndex, []);
             subaddressIndicesForCurrentAccount.Add(expandedInvoice.PaymentMethodDetails.AddressIndex);
-            accountToAddressQuery.AddOrReplace(currentAccountIndex, subaddressIndicesForCurrentAccount);
+            accountToAddressQuery[currentAccountIndex] = subaddressIndicesForCurrentAccount;
         }
 
         var tasks = accountToAddressQuery.ToDictionary(datas => datas.Key,

--- a/Plugins/Monero/Services/MoneroRpcProvider.cs
+++ b/Plugins/Monero/Services/MoneroRpcProvider.cs
@@ -10,8 +10,6 @@ using Monero.Common;
 using Monero.Daemon.Common;
 using Monero.Wallet.Rpc;
 
-using NBitcoin;
-
 namespace BTCPayServer.Plugins.Monero.Services;
 
 public interface IMoneroRpcProvider
@@ -124,10 +122,10 @@ public class MoneroRpcProvider : IMoneroRpcProvider
 
         var changed = !Summaries.ContainsKey(cryptoCode) || IsAvailable(cryptoCode) != IsAvailable(summary);
 
-        Summaries.AddOrReplace(cryptoCode, summary);
+        Summaries[cryptoCode] = summary;
         if (changed)
         {
-            _eventAggregator.Publish(new MoneroDaemonStateChange() { Summary = summary, CryptoCode = cryptoCode });
+            _eventAggregator.Publish(new MoneroDaemonStateChange { Summary = summary, CryptoCode = cryptoCode });
         }
 
         return summary;


### PR DESCRIPTION
fixes https://github.com/btcpay-monero/btcpayserver-monero-plugin/issues/120

this happens also in our build here: https://github.com/btcpay-monero/btcpayserver-monero-plugin/actions/runs/32852253112/job/97815687030#step:9:3425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal collection update operations were streamlined without changing observable behavior.
  * Monero daemon state notifications continue to be published as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->